### PR TITLE
basic.js works.

### DIFF
--- a/src/gfx/CCDeviceGraphics-gl.cpp
+++ b/src/gfx/CCDeviceGraphics-gl.cpp
@@ -116,13 +116,18 @@ void DeviceGraphics::setScissor(int x, int y, int w, int h)
     }
 }
 
-void DeviceGraphics::clear(ClearFlag flags, Color4F *color, uint8_t depth, uint8_t stencil)
+void DeviceGraphics::clear(uint8_t flags, Color4F *color, uint8_t depth, uint8_t stencil)
 {
+    GLbitfield mask = 0;
     if (flags & ClearFlag::COLOR)
+    {
+        mask |= GL_COLOR_BUFFER_BIT;
         glClearColor(color->r, color->g, color->b, color->a);
+    }
     
     if (flags & ClearFlag::DEPTH)
     {
+        mask |= GL_DEPTH_BUFFER_BIT;
         glClearDepth(depth);
         
         glEnable(GL_DEPTH_TEST);
@@ -131,9 +136,12 @@ void DeviceGraphics::clear(ClearFlag flags, Color4F *color, uint8_t depth, uint8
     }
     
     if (flags & ClearFlag::STENCIL)
+    {
+        mask |= GL_STENCIL_BUFFER_BIT;
         glClearStencil(stencil);
+    }
     
-    glClear(flags);
+    glClear(mask);
     
     // Restore depth related state.
     if (flags & ClearFlag::DEPTH)
@@ -273,6 +281,10 @@ void DeviceGraphics::setVertexBuffer(int stream, VertexBuffer* buffer, int start
 {
     _nextState.setVertexBuffer(stream, buffer);
     _nextState.setVertexBufferOffset(stream, start);
+
+    if (_nextState.maxStream < stream) {
+        _nextState.maxStream = stream;
+    }
 }
 
 void DeviceGraphics::setIndexBuffer(IndexBuffer *buffer)

--- a/src/gfx/CCDeviceGraphics.h
+++ b/src/gfx/CCDeviceGraphics.h
@@ -55,7 +55,7 @@ public:
     void setViewport(int x, int y, int w, int h);
     void setScissor(int x, int y, int w, int h);
     
-    void clear(ClearFlag flags, Color4F *color, uint8_t depth, uint8_t stencil);
+    void clear(uint8_t flags, Color4F *color, uint8_t depth, uint8_t stencil);
     
     void enableBlend();
     void enableDepthTest();

--- a/src/gfx/CCState.cpp
+++ b/src/gfx/CCState.cpp
@@ -263,7 +263,6 @@ void State::reset()
 
 void State::setVertexBuffer(size_t index, VertexBuffer* vertBuf)
 {
-    assert(vertBuf != nullptr);
     if (index >= _vertexBuffers.size())
     {
         _vertexBuffers.resize(index + 1);
@@ -272,9 +271,9 @@ void State::setVertexBuffer(size_t index, VertexBuffer* vertBuf)
     VertexBuffer* oldBuf = _vertexBuffers[index];
     if (oldBuf != vertBuf)
     {
-        oldBuf->release();
+        GFX_SAFE_RELEASE(oldBuf);
         _vertexBuffers[index] = vertBuf;
-        vertBuf->retain();
+        GFX_SAFE_RETAIN(vertBuf);
     }
 }
 
@@ -304,12 +303,11 @@ int32_t State::getVertexBufferOffset(size_t index) const
 
 void State::setIndexBuffer(IndexBuffer* indexBuf)
 {
-    assert(indexBuf != nullptr);
     if (_indexBuffer != indexBuf)
     {
-        _indexBuffer->release();
+        GFX_SAFE_RELEASE(_indexBuffer);
         _indexBuffer = indexBuf;
-        indexBuf->retain();
+        GFX_SAFE_RETAIN(_indexBuffer);
     }
 }
 
@@ -320,7 +318,6 @@ IndexBuffer* State::getIndexBuffer() const
 
 void State::setTexture(size_t index, Texture* texture)
 {
-    assert(texture != nullptr);
     if (index >= _textureUnits.size())
     {
         _textureUnits.resize(index + 1);
@@ -329,9 +326,9 @@ void State::setTexture(size_t index, Texture* texture)
     Texture* oldTexture = _textureUnits[index];
     if (oldTexture != texture)
     {
-        oldTexture->release();
+        GFX_SAFE_RELEASE(oldTexture);
         _textureUnits[index] = texture;
-        texture->retain();
+        GFX_SAFE_RETAIN(texture);
     }
 }
 
@@ -348,9 +345,9 @@ void State::setProgram(Program* program)
     assert(program != nullptr);
     if (_program != program)
     {
-        _program->release();
+        GFX_SAFE_RELEASE(_program);
         _program = program;
-        program->retain();
+        GFX_SAFE_RETAIN(_program);
     }
 }
 

--- a/src/gfx/CCVertexBuffer.cpp
+++ b/src/gfx/CCVertexBuffer.cpp
@@ -31,6 +31,7 @@ VertexBuffer::VertexBuffer()
 : _device(nullptr)
 , _usage(Usage::STATIC)
 , _numVertices(0)
+, _bytes(0)
 {
 
 }
@@ -53,6 +54,9 @@ bool VertexBuffer::init(DeviceGraphics* device, const VertexFormat& format, Usag
     _format = format;
     _usage = usage;
     _numVertices = numVertices;
+
+    // calculate bytes
+    _bytes = _format._bytes * numVertices;
 
     // update
     glGenBuffers(1, &_glID);

--- a/src/gfx/CCVertexFormat.cpp
+++ b/src/gfx/CCVertexFormat.cpp
@@ -54,14 +54,12 @@ VertexFormat::VertexFormat()
 
 VertexFormat::VertexFormat(const std::vector<Info>& infos)
 {
+    _bytes = 0;
 #if GFX_DEBUG > 0
     std::vector<Element> _elements;
     std::vector<Element>& elements = _elements;
-    _bytes = 0;
-    uint32_t& bytes = _bytes;
 #else
     std::vector<Element> elements;
-    uint32_t bytes = 0;
 #endif
 
     uint32_t offset = 0;
@@ -81,14 +79,14 @@ VertexFormat::VertexFormat(const std::vector<Info>& infos)
         _attr2el[el.name] = el;
         elements.push_back(el);
 
-        bytes += el.bytes;
+        _bytes += el.bytes;
         offset += el.bytes;
     }
 
     for (size_t i = 0, len = elements.size(); i < len; ++i)
     {
         auto& el = elements[i];
-        el.stride = bytes;
+        el.stride = _bytes;
     }
 }
 

--- a/src/gfx/CCVertexFormat.h
+++ b/src/gfx/CCVertexFormat.h
@@ -39,9 +39,9 @@ public:
     {
         Info(const char* name, AttribType type, uint32_t num, bool normalize = false)
         : _name(name)
-        , _num(0)
-        , _type(AttribType::INVALID)
-        , _normalize(false)
+        , _num(num)
+        , _type(type)
+        , _normalize(normalize)
         {
         }
         const char* _name;
@@ -93,8 +93,10 @@ private:
     std::unordered_map<std::string, Element> _attr2el;
 #if GFX_DEBUG > 0
     std::vector<Element> _elements;
-    uint32_t _bytes;
 #endif
+    uint32_t _bytes;
+
+    friend class VertexBuffer;
 };
 
 GFX_END


### PR DESCRIPTION
test code:

```c++
gfx::DeviceGraphics* device = gfx::DeviceGraphics::getInstance();

    gfx::Program* program = new gfx::Program();
    const char* vertSource = R"(
//       precision highp float;
       attribute vec2 a_position;
       void main () {
           gl_Position = vec4(a_position, 0, 1);
       }
    )";

    const char* fragSource = R"(
//        precision highp float;
        uniform vec4 color;
        void main () {
            gl_FragColor = color;
        }
    )";

    program->init(device, vertSource, fragSource);
    program->link();

    gfx::VertexFormat vertexFmt({
        { gfx::ATTRIB_NAME_POSITION, gfx::AttribType::FLOAT32, 2 }
    });

    float vertex[] = {
        -1, 0,
        0, -1,
        1, 1
    };
    gfx::VertexBuffer* vertexBuffer = new gfx::VertexBuffer();
    vertexBuffer->init(device, vertexFmt, gfx::Usage::STATIC, vertex, sizeof(vertex), 3);

    float time = 0;

    while (!glfwWindowShouldClose(window))
    {
        time += 0.016f;

        device->setViewport(0, 0, 960, 640);

        Color4F clearColor(0.1f, 0.1f, 0.1f, 1.0f);
        device->clear(gfx::ClearFlag::COLOR | gfx::ClearFlag::DEPTH, &clearColor, 1, 0);

        device->setVertexBuffer(0, vertexBuffer);

        float g = std::abs(std::sin(time));
//        float color[] = {1.0f, g, 0.0f, 1.0f};
        device->setUniform("color", 1.0f, g, 0.0f, 1.0f);
        device->setProgram(program);
        device->draw(0, vertexBuffer->getCount());

        glfwSwapBuffers(window);
        glfwPollEvents();
    }

    vertexBuffer->release();
    program->release();
    
    glfwDestroyWindow(window);
    glfwTerminate();
```